### PR TITLE
Follow layout guides

### DIFF
--- a/InstagramLogin.podspec
+++ b/InstagramLogin.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                = 'InstagramLogin'
-  s.version             = '1.3.0'
+  s.version             = '1.3.1'
   s.cocoapods_version   = '>= 1.1.0'
   s.authors             = { 'Ander Goig' => 'goig.ander@gmail.com' }
   s.license             = { :type => 'MIT', :file => 'LICENSE' }

--- a/InstagramLogin/Classes/InstagramLoginViewController.swift
+++ b/InstagramLogin/Classes/InstagramLoginViewController.swift
@@ -93,10 +93,13 @@ open class InstagramLoginViewController: UIViewController {
         view.addSubview(webView)
 
         webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
-        webView.heightAnchor.constraint(equalTo: view.heightAnchor).isActive = true
-        webView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
-        webView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+		
+		NSLayoutConstraint.activate([
+			webView.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor),
+			webView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
+			webView.leftAnchor.constraint(equalTo: view.leftAnchor),
+			webView.rightAnchor.constraint(equalTo: view.rightAnchor)
+			])
 
         if progressView != nil {
             webViewObservation = webView.observe(\.estimatedProgress, changeHandler: progressViewChangeHandler)


### PR DESCRIPTION
That pull request fixes visual issues that may appear if presenting it from `UITabBarController`. Also it's more safe to use layout guides.

Bug representation:
<img width="200" alt="screen shot 2018-04-03 at 18 17 52" src="https://user-images.githubusercontent.com/5610904/38258607-a112e156-376b-11e8-89ed-45e8f2c4fc62.png">

I haven't used newer safeArea guides, because `WKWebView` knows about it and uses it for content insets.

Don't forget to add tag to `1.3.1` if pull request will be accepted.